### PR TITLE
Added fix for sending message to fifo queues

### DIFF
--- a/NetSQS.Mock.Tests/MockTests.cs
+++ b/NetSQS.Mock.Tests/MockTests.cs
@@ -34,27 +34,27 @@ namespace NetSQS.Mock.Tests
         }
 
         [Fact]
-        public async Task MockCreateFifoQueueAsync_ShouldReturnQueueUrl_WhenCreatingFifoQueue()
+        public async Task MockCreateStandardFifoQueueAsync_ShouldReturnQueueUrl_WhenCreatingFifoQueue()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            var queueUrl = await client.CreateFifoQueueAsync("test.fifo");
+            var queueUrl = await client.CreateStandardFifoQueueAsync("test.fifo");
 
             Assert.Equal("https://mockRegion/queue/test.fifo", queueUrl);
         }
 
         [Fact]
-        public async Task MockCreateFifoQueueAsync_ShouldThrowArgumentException_WhenQueueNameDoesNotEndWithFifo()
+        public async Task MockCreateStandardFifoQueueAsync_ShouldThrowArgumentException_WhenQueueNameDoesNotEndWithFifo()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateFifoQueueAsync("test"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateStandardFifoQueueAsync("test"));
         }
 
         [Fact]
         public async Task MockSendMessageAsync_ShouldPutAMessageOnTheQueue_WhenQueueExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
             var messageId = await client.SendMessageAsync("Hello World!", "mockQueue.fifo");
 
             Assert.NotNull(messageId);
@@ -74,7 +74,7 @@ namespace NetSQS.Mock.Tests
         public async Task MockPollQueueAsync_ShouldRetrieveMessage_WhenQueueAndMessageExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
             await client.SendMessageAsync("Hello World!", "mockQueue.fifo");
 
             var cancellationToken = client.PollQueueAsync("mockQueue.fifo", 1, 1, message =>
@@ -94,7 +94,7 @@ namespace NetSQS.Mock.Tests
         public async Task MockPollQueueAsync_ShouldRetrieveMessageWithAsyncProcessor_WhenQueueAndMessageExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
             await client.SendMessageAsync("Hello World!", "mockQueue.fifo");
 
             var cancellationToken = client.PollQueueAsync("mockQueue.fifo", 1, 1, async (message) =>
@@ -114,7 +114,7 @@ namespace NetSQS.Mock.Tests
         public async Task MockPollQueueWithRetryAsync_ShouldRetrieveMessage_WhenQueueAndMessageExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
             await client.SendMessageAsync("Hello World!", "mockQueue.fifo");
 
             var cancellationToken = await client.PollQueueWithRetryAsync("mockQueue.fifo", 1, 1, 10, 1, 10, message =>
@@ -134,7 +134,7 @@ namespace NetSQS.Mock.Tests
         public async Task MockPollQueueWithRetryAsync_ShouldRetrieveMessageWithAsyncMessageProcessor_WhenQueueAndMessageExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
             await client.SendMessageAsync("Hello World!", "mockQueue.fifo");
 
             var cancellationToken = await client.PollQueueWithRetryAsync("mockQueue.fifo", 1, 1, 10, 1, 10, async message =>
@@ -163,7 +163,7 @@ namespace NetSQS.Mock.Tests
         public async Task MockDeleteQueue_ShouldDeleteQueue_IfQueueExists()
         {
             var client = new SQSClientMock("mockEndpoint", "mockRegion");
-            await client.CreateFifoQueueAsync("mockQueue.fifo");
+            await client.CreateStandardFifoQueueAsync("mockQueue.fifo");
 
             var queuesOnClientBeforeDeletion = await client.ListQueuesAsync();
             await client.DeleteQueueAsync("mockQueue.fifo");

--- a/NetSQS.Mock/SQSClientMock.cs
+++ b/NetSQS.Mock/SQSClientMock.cs
@@ -44,7 +44,7 @@ namespace NetSQS.Mock
             return await CreateQueueAsync(queueName, false, false);
         }
 
-        public async Task<string> CreateFifoQueueAsync(string queueName)
+        public async Task<string> CreateStandardFifoQueueAsync(string queueName)
         {
             return await CreateQueueAsync(queueName, true, true);
         }

--- a/NetSQS/AmazonSQS.cs
+++ b/NetSQS/AmazonSQS.cs
@@ -81,10 +81,12 @@ namespace NetSQS
         public async Task<string> SendMessageAsync(string message, string queueName)
         {
             var queueUrl = await GetQueueUrlAsync(queueName);
+            
             var request = new SendMessageRequest
             {
                 QueueUrl = queueUrl,
-                MessageBody = message
+                MessageBody = message,
+                MessageGroupId = queueName.EndsWith(".fifo")? queueUrl : null,
             };
 
             var response = await _client.SendMessageAsync(request);

--- a/NetSQS/AmazonSQS.cs
+++ b/NetSQS/AmazonSQS.cs
@@ -109,7 +109,7 @@ namespace NetSQS
         /// </summary>
         /// <param name="queueName">The name of the queue</param>
         /// <returns></returns>
-        public async Task<string> CreateFifoQueueAsync(string queueName)
+        public async Task<string> CreateStandardFifoQueueAsync(string queueName)
         {
             return await CreateQueueAsync(queueName, true, true);
         }
@@ -146,6 +146,12 @@ namespace NetSQS
 
                 attributes.Add("FifoQueue", "true");
                 attributes.Add("ContentBasedDeduplication", "true");
+            } else
+            {
+                if (queueName.EndsWith(".fifo"))
+                {
+                    throw new ArgumentException("Non fifo queue names can't end with .fifo");
+                }
             }
 
             var request = new CreateQueueRequest

--- a/NetSQS/AmazonSQS.cs
+++ b/NetSQS/AmazonSQS.cs
@@ -146,12 +146,9 @@ namespace NetSQS
 
                 attributes.Add("FifoQueue", "true");
                 attributes.Add("ContentBasedDeduplication", "true");
-            } else
+            } else if (queueName.EndsWith(".fifo"))
             {
-                if (queueName.EndsWith(".fifo"))
-                {
                     throw new ArgumentException("Non fifo queue names can't end with .fifo");
-                }
             }
 
             var request = new CreateQueueRequest

--- a/NetSQS/ISQSClient.cs
+++ b/NetSQS/ISQSClient.cs
@@ -28,7 +28,7 @@ namespace NetSQS
         /// </summary>
         /// <param name="queueName">The name of the queue</param>
         /// <returns></returns>
-        Task<string> CreateFifoQueueAsync(string queueName);
+        Task<string> CreateStandardFifoQueueAsync(string queueName);
 
         /// <summary>
         /// Creates a queue in SQS

--- a/SQSClient.Tests/SQSClientTests.cs
+++ b/SQSClient.Tests/SQSClientTests.cs
@@ -89,6 +89,21 @@ namespace NetSQS.Tests
             await client.DeleteQueueAsync(queueName);
         }
 
+        [Fact]
+        public async Task SendMessageFifoAsync_ShouldPutMessageOnQueue()
+        {
+            var client = CreateSQSClient();
+            var queueName = $"{Guid.NewGuid().ToString()}.fifo";
+            await client.CreateFifoQueueAsync(queueName);
+
+            var message = "Hello World!";
+            var messageId = await client.SendMessageAsync(message, queueName);
+
+            Assert.NotNull(messageId);
+
+            await client.DeleteQueueAsync(queueName);
+        }
+
         private bool MessagePicked { get; set; }
 
         [Fact]

--- a/SQSClient.Tests/SQSClientTests.cs
+++ b/SQSClient.Tests/SQSClientTests.cs
@@ -28,14 +28,22 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public async Task CreateFifoQueueAsync_ShouldCreateFifoQueue()
+        public async Task CreateStandardFifoQueueAsync_ShouldCreateFifoQueue()
         {
             var client = CreateSQSClient();
             var queueName = $"{Guid.NewGuid().ToString()}.fifo";
-            var queueUrl = await client.CreateFifoQueueAsync(queueName);
+            var queueUrl = await client.CreateStandardFifoQueueAsync(queueName);
             Assert.NotEmpty(queueUrl);
 
             await client.DeleteQueueAsync(queueName);
+        }
+
+        [Fact]
+        public async Task CreateQueueAsync_ShouldError_IfNameContainsFifo()
+        {
+            var client = CreateSQSClient();
+            var queueName = $"{Guid.NewGuid().ToString()}.fifo";
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateQueueAsync(queueName, false, true));
         }
 
         [Fact]
@@ -94,7 +102,7 @@ namespace NetSQS.Tests
         {
             var client = CreateSQSClient();
             var queueName = $"{Guid.NewGuid().ToString()}.fifo";
-            await client.CreateFifoQueueAsync(queueName);
+            await client.CreateStandardFifoQueueAsync(queueName);
 
             var message = "Hello World!";
             var messageId = await client.SendMessageAsync(message, queueName);

--- a/SQSClient.Tests/SQSClientTests.cs
+++ b/SQSClient.Tests/SQSClientTests.cs
@@ -90,7 +90,7 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public async Task SendMessageFifoAsync_ShouldPutMessageOnQueue()
+        public async Task SendFifoMessageAsync_ShouldPutMessageOnQueue()
         {
             var client = CreateSQSClient();
             var queueName = $"{Guid.NewGuid().ToString()}.fifo";


### PR DESCRIPTION
When sending a message to a fifo queue the message group id must be set. 
Should not be able to create a non fifo queue with .fifo in the name. 
Renamed CreateFifoQueueAsync to CreateStandardFifoQueueAsync as to line up with the naming on the other default creation methods. 