### PR TITLE
Deprecated faulty signatures and added new ones.

### DIFF
--- a/NetSQS/AmazonSQS.cs
+++ b/NetSQS/AmazonSQS.cs
@@ -347,7 +347,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiver instead.", true)]
         public async Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor)
         {
@@ -371,7 +371,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiver instead.", true)]
         public async Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor)
         {
@@ -393,7 +393,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        public CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
+        public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor)
         {
             Task.Run(async () => await WaitForQueueAsync(queueName, numRetries, minBackOff, maxBackOff)).Wait();
@@ -414,7 +414,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        public CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
+        public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor)
         {
             Task.Run(async () => await WaitForQueueAsync(queueName, numRetries, minBackOff, maxBackOff)).Wait();

--- a/NetSQS/ISQSClient.cs
+++ b/NetSQS/ISQSClient.cs
@@ -91,7 +91,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithConnectionRetry instead.", true)]
         Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor);
 
@@ -108,7 +108,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithConnectionRetry instead.", true)]
         Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor);
 
@@ -125,7 +125,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime,
+        CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime,
             int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor);
 
@@ -142,7 +142,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
-        CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime,
+        CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime,
             int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor);
 

--- a/NetSQS/ISQSClient.cs
+++ b/NetSQS/ISQSClient.cs
@@ -63,6 +63,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="asyncMessageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("PollQueueAsync is deprecated and will be removed, please use StartMessageReceiver instead.", true)]
         CancellationTokenSource PollQueueAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll, Func<string, Task<bool>> asyncMessageProcessor);
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="messageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("PollQueueAsync is deprecated and will be removed, please use StartMessageReceiver instead.", true)]
         CancellationTokenSource PollQueueAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll, Func<string, bool> messageProcessor);
 
         /// <summary>
@@ -89,6 +91,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
         Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor);
 
@@ -105,7 +108,64 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("PollQueueWithRetryAsync is deprecated and will be removed, please use StartMessageReceiverWithRetry instead.", true)]
         Task<CancellationTokenSource> PollQueueWithRetryAsync(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor);
+
+        /// <summary>
+        /// Waits for the queue to be available by checking its availability for a given number of retries, then continuously checks the queue for new messages.
+        /// Handles the messages on the queue in the processor specified.
+        /// Will start a long running task in a parallel thread that is not awaited.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTime">The amount of time the client will look for messages on the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages that will be picked from the queue.</param>
+        /// <param name="numRetries">Number of connection retries to the queue.</param>
+        /// <param name="minBackOff">The minimum back off time for which to look for new messages</param>
+        /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
+        /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
+        /// <returns></returns>
+        CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime,
+            int maxNumberOfMessagesPerPoll,
+            int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor);
+
+        /// <summary>
+        /// Waits for the queue to be available by checking its availability for a given number of retries, then continuously checks the queue for new messages.
+        /// Handles the messages on the queue in the processor specified.
+        /// Will start a long running task in a parallel thread that is not awaited.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTime">The amount of time the client will look for messages on the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages that will be picked from the queue.</param>
+        /// <param name="numRetries">Number of connection retries to the queue.</param>
+        /// <param name="minBackOff">The minimum back off time for which to look for new messages</param>
+        /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
+        /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
+        /// <returns></returns>
+        CancellationTokenSource StartMessageReceiverWithRetry(string queueName, int pollWaitTime,
+            int maxNumberOfMessagesPerPoll,
+            int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor);
+
+        /// <summary>
+        /// Starts a long running process that checks the queue for any new messages, and handles the messages on the queue in the processor specified.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTime">The waiting time for each poll of the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
+        /// <param name="asyncMessageProcessor">The message processor that handles the message received from the queue.</param>
+        /// <returns></returns>
+        CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
+            Func<string, Task<bool>> asyncMessageProcessor);
+
+        /// <summary>
+        /// Starts a long running process that checks the queue for any new messages, and handles the messages on the queue in the processor specified.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTime">The waiting time for each poll of the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
+        /// <param name="messageProcessor">The message processor that handles the message received from the queue.</param>
+        /// <returns></returns>
+        CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
+            Func<string, bool> messageProcessor);
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ public void WriteToConsole(string message)
 
 public MessagePolling() 
 {
-    var fooCancellationToken = client.PollQueueAsync("nameofthequeue", 0, 1, AddSomethingToDb);
-    var barCancellationToken = client.PollQueueAsync("nameofthequeue", 0, 1, WriteToConsole);
+    var fooCancellationToken = client.StartMessageReceiver("nameofthequeue", 0, 1, AddSomethingToDb);
+    var barCancellationToken = client.StartMessageReceiver("nameofthequeue", 0, 1, WriteToConsole);
     
     // If you want to cancel the parallel tasks created by these methods. Do this:
     fooCancellationToken.Cancel();
     barCancellationToken.Cancel();
 }
 ```
-You can also use `PollQueueWithRetryAsync` to automatically retry a connection to the queue if there has been an error while connecting. This is specified with a number of retries and a min and max backoff for the retry:
+You can also use `StartMessageReceiver` to automatically retry a connection to the queue if there has been an error while connecting. This is specified with a number of retries and a min and max backoff for the retry:
 ```csharp
-var task = PollQueueWithRetryAsync(queueName: "nameofthequeue", pollWaitTime: 0, maxNumberOfMessagesPerPoll: 1, numRetries: 20, minBackOff: 1, maxBackOff: 20, AddSomethingToDb);
+var task = StartMessageReceiver(queueName: "nameofthequeue", pollWaitTime: 0, maxNumberOfMessagesPerPoll: 1, numRetries: 20, minBackOff: 1, maxBackOff: 20, AddSomethingToDb);
 ```
 
 ## Contributing

--- a/SQSClient.Tests/SQSClientTests.cs
+++ b/SQSClient.Tests/SQSClientTests.cs
@@ -125,7 +125,7 @@ namespace NetSQS.Tests
             await client.SendMessageAsync(message, queueName);
 
             MessagePicked = false;
-            var cancellationToken = client.PollQueueAsync(queueName, 1, 1, (string receivedMessage) =>
+            var cancellationToken = client.StartMessageReceiver(queueName, 1, 1, (string receivedMessage) =>
             {
                 Assert.Equal("Hello World!", receivedMessage);
                 MessagePicked = true;
@@ -153,7 +153,7 @@ namespace NetSQS.Tests
 
             MessagePicked = false;
 
-            var cancellationToken = client.PollQueueAsync(queueName, 1, 1, async (string receivedMessage) =>
+            var cancellationToken = client.StartMessageReceiver(queueName, 1, 1, async (string receivedMessage) =>
             {
                 Assert.Equal("Hello World!", receivedMessage);
                 MessagePicked = true;
@@ -170,12 +170,12 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public async Task PollQueueWithRetryAsync_ShouldThrowErrorWithAsyncMethod_IfQueueDoesNotExist()
+        public void PollQueueWithRetryAsync_ShouldThrowErrorWithAsyncMethod_IfQueueDoesNotExist()
         {
             var queueName = $"{Guid.NewGuid().ToString()}";
             var client = CreateSQSClient();
 
-            await Assert.ThrowsAsync<QueueDoesNotExistException>(() => client.PollQueueWithRetryAsync(queueName, 1, 1, 2, 1, 10, async (string message) =>
+            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiverWithRetry(queueName, 1, 1, 2, 1, 10, async (string message) =>
              {
                  Assert.Equal("Hello World!", message);
                  return await Task.FromResult(true);
@@ -183,12 +183,12 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public async Task PollQueueWithRetryAsync_ShouldThrowError_IfQueueDoesNotExist()
+        public void PollQueueWithRetryAsync_ShouldThrowError_IfQueueDoesNotExist()
         {
             var queueName = $"{Guid.NewGuid().ToString()}";
             var client = CreateSQSClient();
 
-            await Assert.ThrowsAsync<QueueDoesNotExistException>(() => client.PollQueueWithRetryAsync(queueName, 1, 1, 2, 1, 10, (string message) =>
+            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiverWithRetry(queueName, 1, 1, 2, 1, 10, (string message) =>
             {
                 Assert.Equal("Hello World!", message);
                 return true;

--- a/SQSClient.Tests/SQSClientTests.cs
+++ b/SQSClient.Tests/SQSClientTests.cs
@@ -115,7 +115,7 @@ namespace NetSQS.Tests
         private bool MessagePicked { get; set; }
 
         [Fact]
-        public async Task PollQueueAsync_ShouldPickMessageFromQueue_GivenSynchronousMethod()
+        public async Task StartMessageReceiver_ShouldPickMessageFromQueue_GivenSynchronousMethod()
         {
             var client = CreateSQSClient();
             var queueName = $"{Guid.NewGuid().ToString()}";
@@ -142,7 +142,7 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public async Task PollQueueAsync_ShouldPickMessageFromQueue_GivenAsynchronousMethod()
+        public async Task StartMessageReceiver_ShouldPickMessageFromQueue_GivenAsynchronousMethod()
         {
             var client = CreateSQSClient();
             var queueName = $"{Guid.NewGuid().ToString()}";
@@ -170,12 +170,12 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public void PollQueueWithRetryAsync_ShouldThrowErrorWithAsyncMethod_IfQueueDoesNotExist()
+        public void StartMessageReceiver_ShouldThrowErrorWithAsyncMethod_IfQueueDoesNotExist()
         {
             var queueName = $"{Guid.NewGuid().ToString()}";
             var client = CreateSQSClient();
 
-            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiverWithRetry(queueName, 1, 1, 2, 1, 10, async (string message) =>
+            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiver(queueName, 1, 1, 2, 1, 10, async (string message) =>
              {
                  Assert.Equal("Hello World!", message);
                  return await Task.FromResult(true);
@@ -183,12 +183,12 @@ namespace NetSQS.Tests
         }
 
         [Fact]
-        public void PollQueueWithRetryAsync_ShouldThrowError_IfQueueDoesNotExist()
+        public void StartMessageReceiver_ShouldThrowError_IfQueueDoesNotExist()
         {
             var queueName = $"{Guid.NewGuid().ToString()}";
             var client = CreateSQSClient();
 
-            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiverWithRetry(queueName, 1, 1, 2, 1, 10, (string message) =>
+            Assert.Throws<QueueDoesNotExistException>(() => client.StartMessageReceiver(queueName, 1, 1, 2, 1, 10, (string message) =>
             {
                 Assert.Equal("Hello World!", message);
                 return true;


### PR DESCRIPTION
Deprecated:
 - PollQueueAsync
 - PollQueueWithRetryAsync

These where neither async, nor does the consumer need to know that it is polling.

Added:
 - StartMessageReceiver

Indicates to the consumer that these are long running tasks