### PR TITLE
Retry receive message

### DIFF
--- a/NetSQS/ISQSClient.cs
+++ b/NetSQS/ISQSClient.cs
@@ -67,6 +67,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime,
             int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor);
@@ -103,6 +104,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime,
             int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor);
@@ -134,6 +136,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="asyncMessageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             Func<string, Task<bool>> asyncMessageProcessor);
 
@@ -157,6 +160,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="messageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             Func<string, bool> messageProcessor);
 

--- a/NetSQS/SQSClient.cs
+++ b/NetSQS/SQSClient.cs
@@ -249,6 +249,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="asyncMessageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll, Func<string, Task<bool>> asyncMessageProcessor)
         {
             var cancellationTokenSource = new CancellationTokenSource();
@@ -265,6 +266,7 @@ namespace NetSQS
         /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
         /// <param name="messageProcessor">The message processor that handles the message received from the queue.</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll, Func<string, bool> messageProcessor)
         {
             var cancellationTokenSource = new CancellationTokenSource();
@@ -316,6 +318,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, Task<bool>> asyncMessageProcessor)
         {
@@ -384,6 +387,7 @@ namespace NetSQS
         /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
         /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
         /// <returns></returns>
+        [Obsolete("Use StartMessageReceiver-method that takes cancellation token as a parameter. This method will be removed in future releases", true)]
         public CancellationTokenSource StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             int numRetries, int minBackOff, int maxBackOff, Func<string, bool> messageProcessor)
         {

--- a/NetSQS/SQSClient.cs
+++ b/NetSQS/SQSClient.cs
@@ -507,7 +507,7 @@ namespace NetSQS
             };
 
             ReceiveMessageResponse response = null;
-            var retryCounter = 0;
+            var delayTime = 0;
 
             while (response == null)
             {
@@ -517,10 +517,10 @@ namespace NetSQS
                 }
                 catch (AmazonSQSException e)
                 {
-                    if (e.Message.EndsWith("Throttled") && retryCounter < 10)
+                    if (e.Message.EndsWith("Throttled"))
                     {
-                        retryCounter += 1;
-                        await Task.Delay(retryCounter * 3);
+                        if (delayTime < 100) delayTime += 4;
+                        await Task.Delay(delayTime);
                     }
                     else
                     {


### PR DESCRIPTION
- Now does exponential back-off of receiving message if the SQS client returns a message saying that the Queue has been throttled.
- Marked methods returning CancellationTokenSource as obsolete, since best practices says that cancellationtoken should be passed to methods. Not returned from them.