### PR TITLE
Added new method where message can be explicitly acked by consumer

### DIFF
--- a/NetSQS.sln
+++ b/NetSQS.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS", "NetSQS\NetSQS.csp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetSQS.Tests", "SQSClient.Tests\NetSQS.Tests.csproj", "{83760076-DF61-4005-AAC0-E55D9F44A549}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{58960B40-7F1C-4849-B93E-CFDB0CD5CD41}"
+	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/NetSQS/ISQSClient.cs
+++ b/NetSQS/ISQSClient.cs
@@ -175,5 +175,83 @@ namespace NetSQS
         /// <returns></returns>
         Task StartMessageReceiver(string queueName, int pollWaitTime, int maxNumberOfMessagesPerPoll,
             Func<string, bool> messageProcessor, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Starts a long running process that checks the queue for any new messages, and handles the messages on the queue in the processor specified.
+        ///
+        /// Message should be explicitly acked to be removed from queue.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTimeSeconds">The waiting time for each poll of the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
+        /// <param name="messageProcessor">The message processor that handles the message received from the queue.</param>
+        /// <param name="cancellationToken">The receiver process will check the status of this token and cancel the long running process if cancellation is requested.</param>
+        /// <returns></returns>
+        Task StartMessageReceiver(string queueName, int pollWaitTimeSeconds, int maxNumberOfMessagesPerPoll,
+            Action<ISQSMessage> messageProcessor, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Starts a long running process that checks the queue for any new messages, and handles the messages on the queue in the processor specified.
+        ///
+        /// Message should be explicitly acked to be removed from queue.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTimeSeconds">The waiting time for each poll of the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages to get with each poll. Valid values: 1 to 10</param>
+        /// <param name="asyncMessageProcessor">The message processor that handles the message received from the queue.</param>
+        /// <param name="cancellationToken">The receiver process will check the status of this token and cancel the long running process if cancellation is requested.</param>
+        /// <returns></returns>
+        Task StartMessageReceiver(string queueName, int pollWaitTimeSeconds, int maxNumberOfMessagesPerPoll,
+            Func<ISQSMessage, Task> asyncMessageProcessor, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Waits for the queue to be available by checking its availability for a given number of retries, then continuously checks the queue for new messages.
+        /// Handles the messages on the queue in the processor specified.
+        /// Will start a long running task in a parallel thread that is not awaited.
+        ///
+        /// Message should be explicitly acked to be removed from queue.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTimeSeconds">The amount of time the client will look for messages on the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages that will be picked from the queue.</param>
+        /// <param name="numRetries">Number of connection retries to the queue.</param>
+        /// <param name="minBackOff">The minimum back off time for which to look for new messages</param>
+        /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
+        /// <param name="messageProcessor">The message processor which will handle the message picked from the queue</param>
+        /// <param name="cancellationToken">The receiver process will check the status of this token and cancel the long running process if cancellation is requested.</param>
+        /// <returns></returns>
+        Task StartMessageReceiver(string queueName, int pollWaitTimeSeconds,
+            int maxNumberOfMessagesPerPoll,
+            int numRetries, int minBackOff, int maxBackOff, Action<ISQSMessage> messageProcessor,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Waits for the queue to be available by checking its availability for a given number of retries, then continuously checks the queue for new messages.
+        /// Handles the messages on the queue in the processor specified.
+        /// Will start a long running task in a parallel thread that is not awaited.
+        ///
+        /// Message should be explicitly acked to be removed from queue.
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="pollWaitTimeSeconds">The amount of time the client will look for messages on the queue</param>
+        /// <param name="maxNumberOfMessagesPerPoll">The maximum number of messages that will be picked from the queue.</param>
+        /// <param name="numRetries">Number of connection retries to the queue.</param>
+        /// <param name="minBackOff">The minimum back off time for which to look for new messages</param>
+        /// <param name="maxBackOff">The maximum back off time for which to look for new messages</param>
+        /// <param name="asyncMessageProcessor">The message processor which will handle the message picked from the queue</param>
+        /// <param name="cancellationToken">The receiver process will check the status of this token and cancel the long running process if cancellation is requested.</param>
+        /// <returns></returns>
+        Task StartMessageReceiver(string queueName, int pollWaitTimeSeconds,
+            int maxNumberOfMessagesPerPoll,
+            int numRetries, int minBackOff, int maxBackOff, Func<ISQSMessage, Task> asyncMessageProcessor,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes a message from the queue
+        /// </summary>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="receiptHandle">The identifier of the operation that received the message</param>
+        /// <returns></returns>
+        Task DeleteMessageAsync(string queueName, string receiptHandle);
     }
 }

--- a/NetSQS/SQSMessage.cs
+++ b/NetSQS/SQSMessage.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+
+namespace NetSQS
+{
+    public class SQSMessage : ISQSMessage
+    {
+        /// <summary>
+        /// Creates a new SQSMessage instance, used when explicit acknowledging of the message is needed.
+        /// </summary>
+        /// <param name="client">The SQS client instance</param>
+        /// <param name="queueName">The name of the queue</param>
+        /// <param name="receiptHandle">The receipt handle of the message</param>
+        public SQSMessage(SQSClient client, string queueName, string receiptHandle)
+        {
+            Client = client;
+            QueueName = queueName;
+            ReceiptHandle = receiptHandle;
+        }
+
+        /// <summary>
+        /// The content of the message picked off the queue
+        /// </summary>
+        public string Body { get; set; }
+        private SQSClient Client { get; }
+        private string QueueName { get; }
+        private string ReceiptHandle { get; }
+
+        /// <summary>
+        /// Deletes the message from the Queue when called.
+        /// </summary>
+        /// <returns></returns>
+        public async Task Ack()
+        {
+            await Client.DeleteMessageAsync(QueueName, ReceiptHandle);
+        }
+    }
+
+    public interface ISQSMessage
+    {
+        /// <summary>
+        /// The content of the message picked off the queue
+        /// </summary>
+        string Body { get; set; }
+
+        /// <summary>
+        /// Deletes the message from the Queue when called.
+        /// </summary>
+        /// <returns></returns>
+        Task Ack();
+    }
+}


### PR DESCRIPTION
So we ran in to a problem where we weren't able to delete the messages from the queue since the visibility timeout had expired.

However, there was nothing wrong with the processing and a message got stored in the database.

This means that a message will be put back on the queue and stored again, and again, and again.

I added a message type that can explicitly be acknowledged by the consumer so that we don't store the messages if they aren't able to be deleted.

Usage example:

```csharp
public async Task MessageProcessor(ISQSMessage message) 
{
    context.BeginTransaction();
    try
    {
        await ProcessMessage(message.Body); //This takes too much time
        await message.Ack(); // Should throw exception here if not able to delete message and rollback
        context.CommitTransaction();
    }
    catch
    {
        context.RollbackTransaction();
    }
} 
```